### PR TITLE
Removed local var bytesReceived, not necessary anymore in connection:didReceiveData method

### DIFF
--- a/STHTTPRequest.m
+++ b/STHTTPRequest.m
@@ -688,11 +688,9 @@ static NSMutableDictionary *sharedCredentialsStorage = nil;
 - (void)connection:(NSURLConnection *)connection didReceiveData:(NSData *)theData {
 
     [_responseData appendData:theData];
-
-    NSInteger bytesReceived = [theData length];
     
     if (_downloadProgressBlock) {
-        _downloadProgressBlock(bytesReceived, [_responseData length], self.responseExpectedContentLength);
+        _downloadProgressBlock([theData length], [_responseData length], self.responseExpectedContentLength);
     } 
 }
 


### PR DESCRIPTION
Inspired by your code reduction of total bytes received, this pull request eliminates a superfluous local method variable too.
