### PR TITLE
Removed extra space after application/x-www-form-urlencoded

### DIFF
--- a/STHTTPRequest.m
+++ b/STHTTPRequest.m
@@ -451,7 +451,7 @@ static NSMutableArray *localCookiesStorage = nil;
             NSString *encodingName = (NSString *)CFStringConvertEncodingToIANACharSetName(cfStringEncoding);
             
             if(encodingName) {
-                NSString *contentTypeValue = [NSString stringWithFormat:@"application/x-www-form-urlencoded ; charset=%@", encodingName];
+                NSString *contentTypeValue = [NSString stringWithFormat:@"application/x-www-form-urlencoded; charset=%@", encodingName];
                 [self setHeaderWithName:@"Content-Type" value:contentTypeValue];
             }
         }


### PR DESCRIPTION
Removed extra space after application/x-www-form-urlencoded. When using this library with the Express framework for node.js (http://expressjs.com/) none of the POST endpoints were being executed. I guess they don't trim the content type which causes the POST endpoint to not be found.
