### PR TITLE
Add pod specification

### DIFF
--- a/LICENCE
+++ b/LICENCE
@@ -1,0 +1,24 @@
+Copyright (c) 1998, Regents of the University of California
+All rights reserved.
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright
+  notice, this list of conditions and the following disclaimer in the
+  documentation and/or other materials provided with the distribution.
+* Neither the name of the University of California, Berkeley nor the
+  names of its contributors may be used to endorse or promote products
+  derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE REGENTS AND CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/STHTTPRequest.podspec
+++ b/STHTTPRequest.podspec
@@ -1,0 +1,11 @@
+Pod::Spec.new do |s|
+  s.name          = "STHTTPRequest"
+  s.version       = "1.0.0"
+  s.summary       = "A NSURLConnection wrapper for humans"
+  s.homepage      = "https://github.com/nst/STHTTPRequest"
+  s.license       = { :type => 'BSD', :file => 'LICENSE' }
+  s.author        = { "nst" => "XXX@XXX.XXX" }
+  s.source        = { :git => "https://github.com/nst/STHTTPRequest.git", :tag => "1.0.0" }
+  s.source_files  = 'STHTTPRequest.{h,m}'
+  s.requires_arc  = true
+end


### PR DESCRIPTION
Related to issue #17.

The pod specification is incomplete, please edit the "s.author" key in STHTTPRequest.podspec (I guess remove the entire line could work too).

It also require that you create a github release or tag (named 1.0.0 according to the podspec or edit the podfile) before submitting it to CocoaPods.
