### PR TITLE
Fixed warnings in Xcode 9

### DIFF
--- a/STHTTPRequest.h
+++ b/STHTTPRequest.h
@@ -57,7 +57,7 @@ typedef NS_ENUM(NSUInteger, STHTTPRequestCookiesStorage) {
 @property (nonatomic) STHTTPRequestCookiesStorage cookieStoragePolicyForInstance; // overrides globalCookiesStoragePolicy
 @property (nonatomic) NSString *sharedContainerIdentifier;
 
-+ (void)setBackgroundCompletionHandler:(void(^)())completionHandler forSessionIdentifier:(NSString *)sessionIdentifier;
++ (void)setBackgroundCompletionHandler:(void(^)(void))completionHandler forSessionIdentifier:(NSString *)sessionIdentifier;
 //+ (void(^)())backgroundCompletionHandlerForSessionIdentifier:(NSString *)sessionIdentifier;
 
 // response

--- a/STHTTPRequest.m
+++ b/STHTTPRequest.m
@@ -921,7 +921,7 @@ static STHTTPRequestCookiesStorage globalCookiesStoragePolicy = STHTTPRequestCoo
     self.errorBlock(self.error);
 }
 
-+ (void)setBackgroundCompletionHandler:(void(^)())completionHandler forSessionIdentifier:(NSString *)sessionIdentifier {
++ (void)setBackgroundCompletionHandler:(void(^)(void))completionHandler forSessionIdentifier:(NSString *)sessionIdentifier {
     if(sessionCompletionHandlersForIdentifier == nil) {
         sessionCompletionHandlersForIdentifier = [NSMutableDictionary dictionary];
     }
@@ -970,7 +970,7 @@ static STHTTPRequestCookiesStorage globalCookiesStoragePolicy = STHTTPRequestCoo
     
     dispatch_async(dispatch_get_main_queue(), ^{
         
-        void (^completionHandler)() = sessionCompletionHandlersForIdentifier[session.configuration.identifier];
+        void (^completionHandler)(void) = sessionCompletionHandlersForIdentifier[session.configuration.identifier];
         
         if(completionHandler) {
             completionHandler();


### PR DESCRIPTION
Fixed "This block declaration is not a prototype"warning in Xcode 9.